### PR TITLE
Closes #5 - Redundant Submits

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ chainpoint = Chainpoint.new
 
 ### Submit Hash
 
+Use this function to submit a hashes, and receive back the information needed to later retrieve a proof using `get_proof`
+
+By default hashes are submitted to three Nodes to help ensure a proof will become available at the appropriate time. Only one such proof need be permanently stored, the others provide redundancy.
+
 ```ruby
 # hash is SHA256
 # hash = '2fbe59be2be10a4fdeca9c6d3e9f56fc56fb3ee9a8ef2e9be37fced60c264681'

--- a/docs/Chainpoint.html
+++ b/docs/Chainpoint.html
@@ -137,6 +137,18 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
 
     <dl class="constants">
       
+        <dt id="NODE_LIST_ENDPOINTS-constant" class="">NODE_LIST_ENDPOINTS =
+          
+        </dt>
+        <dd><pre class="code"><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>https://a.chainpoint.org/nodes/random</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span>
+<span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>https://b.chainpoint.org/nodes/random</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span>
+<span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>https://c.chainpoint.org/nodes/random</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
+      
+        <dt id="NUM_SERVERS-constant" class="">NUM_SERVERS =
+          
+        </dt>
+        <dd><pre class="code"><span class='int'>3</span></pre></dd>
+      
         <dt id="VERSION-constant" class="">VERSION =
           
         </dt>
@@ -162,7 +174,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#get_proof-class_method" title="get_proof (class method)">.<strong>get_proof</strong>(hash_id_node)  &#x21d2; Object </a>
+      <a href="#get_proof-class_method" title="get_proof (class method)">.<strong>get_proof</strong>(uri, node_hash_id)  &#x21d2; JSON </a>
     
 
     
@@ -267,7 +279,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#get_proof-instance_method" title="#get_proof (instance method)">#<strong>get_proof</strong>(hash_id_node)  &#x21d2; JSON </a>
+      <a href="#get_proof-instance_method" title="#get_proof (instance method)">#<strong>get_proof</strong>(node_hash_id)  &#x21d2; JSON </a>
     
 
     
@@ -291,7 +303,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(server_url = nil)  &#x21d2; Chainpoint </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(server_url = nil, num_servers: NUM_SERVERS)  &#x21d2; Chainpoint </a>
     
 
     
@@ -395,7 +407,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(server_url = nil)  &#x21d2; <tt><span class='object_link'><a href="" title="Chainpoint (class)">Chainpoint</a></span></tt> 
+    #<strong>initialize</strong>(server_url = nil, num_servers: NUM_SERVERS)  &#x21d2; <tt><span class='object_link'><a href="" title="Chainpoint (class)">Chainpoint</a></span></tt> 
   
 
   
@@ -418,23 +430,15 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-25
-26
-27
-28
-29
-30
-31</pre>
+31
+32
+33</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 25</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 31</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_server_url'>server_url</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span>
-  <span class='kw'>if</span> <span class='id identifier rubyid_server_url'>server_url</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
-    <span class='ivar'>@server_url</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_pickup_server'>pickup_server</span>
-    <span class='kw'>return</span>
-  <span class='kw'>end</span>
-  <span class='ivar'>@server_url</span> <span class='op'>=</span> <span class='id identifier rubyid_server_url'>server_url</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_server_url'>server_url</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>num_servers:</span> <span class='const'><span class='object_link'><a href="#NUM_SERVERS-constant" title="Chainpoint::NUM_SERVERS (constant)">NUM_SERVERS</a></span></span><span class='rparen'>)</span>
+  <span class='ivar'>@server_urls</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='id identifier rubyid_server_url'>server_url</span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='id identifier rubyid_pickup_servers'>pickup_servers</span><span class='lparen'>(</span><span class='id identifier rubyid_num_servers'>num_servers</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -451,7 +455,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <div class="method_details first">
   <h3 class="signature first" id="get_proof-class_method">
   
-    .<strong>get_proof</strong>(hash_id_node)  &#x21d2; <tt>Object</tt> 
+    .<strong>get_proof</strong>(uri, node_hash_id)  &#x21d2; <tt>JSON</tt> 
   
 
   
@@ -471,7 +475,23 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
   
     <li>
       
-        <span class='name'>hash_id_node</span>
+        <span class='name'>URI</span>
+      
+      
+        <span class='type'>(<tt>String</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>hash id node of the proof</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>node_hash_id</span>
       
       
         <span class='type'>(<tt>String</tt>)</span>
@@ -487,6 +507,19 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
   
 </ul>
 
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>JSON</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
 
 </div><table class="source_code">
   <tr>
@@ -494,15 +527,15 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-74
-75
-76</pre>
+80
+81
+82</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 74</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 80</span>
 
-<span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_get_proof'>get_proof</span><span class='lparen'>(</span><span class='id identifier rubyid_hash_id_node'>hash_id_node</span><span class='rparen'>)</span>
-  <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_get_proof'>get_proof</span><span class='lparen'>(</span><span class='id identifier rubyid_hash_id_node'>hash_id_node</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_get_proof'>get_proof</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='comma'>,</span> <span class='id identifier rubyid_node_hash_id'>node_hash_id</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_get_proof'>get_proof</span><span class='lparen'>(</span><span class='id identifier rubyid_node_hash_id'>node_hash_id</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -555,12 +588,12 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-51
-52
-53</pre>
+53
+54
+55</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 51</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 53</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_submit'>submit</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_submit'>submit</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='rparen'>)</span>
@@ -616,12 +649,12 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-36
-37
-38</pre>
+38
+39
+40</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 36</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 38</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_submit_data'>submit_data</span><span class='lparen'>(</span><span class='id identifier rubyid_data'>data</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_submit_data'>submit_data</span><span class='lparen'>(</span><span class='id identifier rubyid_data'>data</span><span class='rparen'>)</span>
@@ -677,15 +710,15 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-91
-92
-93</pre>
+96
+97
+98</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 91</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 96</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_verify'>verify</span><span class='lparen'>(</span><span class='id identifier rubyid_proof'>proof</span><span class='rparen'>)</span>
-  <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_verify'>verify</span><span class='lparen'>(</span><span class='id identifier rubyid_proof'>proof</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='label'>num_servers:</span> <span class='int'>1</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_verify'>verify</span><span class='lparen'>(</span><span class='id identifier rubyid_proof'>proof</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -701,7 +734,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <div class="method_details first">
   <h3 class="signature first" id="get_proof-instance_method">
   
-    #<strong>get_proof</strong>(hash_id_node)  &#x21d2; <tt>JSON</tt> 
+    #<strong>get_proof</strong>(node_hash_id)  &#x21d2; <tt>JSON</tt> 
   
 
   
@@ -757,19 +790,17 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-82
-83
-84
-85
-86</pre>
+88
+89
+90
+91</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 82</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 88</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_get_proof'>get_proof</span><span class='lparen'>(</span><span class='id identifier rubyid_hash_id_node'>hash_id_node</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='const'>URI</span><span class='lparen'>(</span><span class='ivar'>@server_url</span> <span class='op'>+</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/proofs/</span><span class='tstring_end'>&#39;</span></span> <span class='op'>+</span> <span class='id identifier rubyid_hash_id_node'>hash_id_node</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_r'>r</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='period'>.</span><span class='id identifier rubyid_get'>get</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='rparen'>)</span>
-  <span class='kw'>return</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_r'>r</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_get_proof'>get_proof</span><span class='lparen'>(</span><span class='id identifier rubyid_node_hash_id'>node_hash_id</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='const'>URI</span><span class='lparen'>(</span><span class='ivar'>@server_urls</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span> <span class='op'>+</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/proofs/</span><span class='tstring_end'>&#39;</span></span> <span class='op'>+</span> <span class='id identifier rubyid_node_hash_id'>node_hash_id</span><span class='rparen'>)</span>
+  <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='period'>.</span><span class='id identifier rubyid_get'>get</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='rparen'>)</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -827,7 +858,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       
         &mdash;
         <div class='inline'>
-<p>An array of hashes containing the keys `hash`, `hash_id_node` and `uri`</p>
+<p>An array of Chainpoint::Hash objects</p>
 </div>
       
     </li>
@@ -840,8 +871,6 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-59
-60
 61
 62
 63
@@ -850,21 +879,27 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
 66
 67
 68
-69</pre>
+69
+70
+71
+72
+73</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 59</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 61</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_submit'>submit</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='const'>URI</span><span class='lparen'>(</span><span class='ivar'>@server_url</span> <span class='op'>+</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/hashes</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='op'>::</span><span class='const'>Post</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Content-Type</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>application/json</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_request'>request</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='lbrace'>{</span> <span class='label'>hashes:</span> <span class='lbracket'>[</span><span class='id identifier rubyid_hash'>hash</span><span class='rbracket'>]</span> <span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_to_json'>to_json</span>
-  <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='period'>.</span><span class='id identifier rubyid_start'>start</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_hostname'>hostname</span><span class='comma'>,</span> <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_port'>port</span><span class='comma'>,</span> <span class='label'>use_ssl:</span> <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_scheme'>scheme</span> <span class='op'>==</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>https</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_http'>http</span><span class='op'>|</span>
-    <span class='id identifier rubyid_http'>http</span><span class='period'>.</span><span class='id identifier rubyid_request'>request</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
-  <span class='kw'>end</span>
+  <span class='ivar'>@server_urls</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_url'>url</span><span class='op'>|</span>
+    <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='const'>URI</span><span class='lparen'>(</span><span class='id identifier rubyid_url'>url</span> <span class='op'>+</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/hashes</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+    <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='op'>::</span><span class='const'>Post</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Content-Type</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>application/json</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+    <span class='id identifier rubyid_request'>request</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='lbrace'>{</span> <span class='label'>hashes:</span> <span class='lbracket'>[</span><span class='id identifier rubyid_hash'>hash</span><span class='rbracket'>]</span> <span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_to_json'>to_json</span>
 
-  <span class='id identifier rubyid_hashes'>hashes</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>hashes</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
-  <span class='id identifier rubyid_hashes'>hashes</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_hash'>hash</span><span class='op'>|</span> <span class='id identifier rubyid_hash'>hash</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>uri</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='ivar'>@server_url</span><span class='rparen'>)</span> <span class='rbrace'>}</span>
+    <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='period'>.</span><span class='id identifier rubyid_start'>start</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_hostname'>hostname</span><span class='comma'>,</span> <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_port'>port</span><span class='comma'>,</span> <span class='label'>use_ssl:</span> <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_scheme'>scheme</span> <span class='op'>==</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>https</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_http'>http</span><span class='op'>|</span>
+      <span class='id identifier rubyid_http'>http</span><span class='period'>.</span><span class='id identifier rubyid_request'>request</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
+    <span class='kw'>end</span>
+
+    <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>hashes</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_hash'>hash</span><span class='op'>|</span> <span class='id identifier rubyid_hash'>hash</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>uri</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='id identifier rubyid_url'>url</span><span class='rparen'>)</span> <span class='rbrace'>}</span>
+  <span class='kw'>end</span><span class='period'>.</span><span class='id identifier rubyid_flatten'>flatten</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -917,13 +952,13 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-43
-44
 45
-46</pre>
+46
+47
+48</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 43</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 45</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_submit_data'>submit_data</span><span class='lparen'>(</span><span class='id identifier rubyid_data'>data</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_hash'>hash</span> <span class='op'>=</span> <span class='const'>Digest</span><span class='op'>::</span><span class='const'>SHA256</span><span class='period'>.</span><span class='id identifier rubyid_digest'>digest</span><span class='lparen'>(</span><span class='id identifier rubyid_data'>data</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_unpack'>unpack</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>H*</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='int'>0</span><span class='rbracket'>]</span>
@@ -980,31 +1015,31 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <pre class="lines">
 
 
-98
-99
-100
-101
-102
 103
 104
 105
 106
 107
-108</pre>
+108
+109
+110
+111
+112
+113</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 98</span>
+      <pre class="code"><span class="info file"># File 'lib/chainpoint.rb', line 103</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_verify'>verify</span><span class='lparen'>(</span><span class='id identifier rubyid_proof'>proof</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='const'>URI</span><span class='lparen'>(</span><span class='ivar'>@server_url</span> <span class='op'>+</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/verify</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_req'>req</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='op'>::</span><span class='const'>Post</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Content-Type</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>application/json</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_req'>req</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='label'>proofs:</span> <span class='lbracket'>[</span><span class='id identifier rubyid_proof'>proof</span><span class='rbracket'>]</span><span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_to_json'>to_json</span>
-  <span class='id identifier rubyid_res'>res</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='period'>.</span><span class='id identifier rubyid_start'>start</span><span class='lparen'>(</span>
-    <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_hostname'>hostname</span><span class='comma'>,</span> <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_port'>port</span><span class='comma'>,</span> <span class='label'>use_ssl:</span> <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_scheme'>scheme</span> <span class='op'>==</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>https</span><span class='tstring_end'>&quot;</span></span>
-  <span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_http'>http</span><span class='op'>|</span>
-    <span class='id identifier rubyid_http'>http</span><span class='period'>.</span><span class='id identifier rubyid_request'>request</span><span class='lparen'>(</span><span class='id identifier rubyid_req'>req</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='const'>URI</span><span class='lparen'>(</span><span class='ivar'>@server_urls</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span> <span class='op'>+</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/verify</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='op'>::</span><span class='const'>Post</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Content-Type</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>application/json</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_request'>request</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='lbrace'>{</span> <span class='label'>proofs:</span> <span class='lbracket'>[</span><span class='id identifier rubyid_proof'>proof</span><span class='rbracket'>]</span> <span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_to_json'>to_json</span>
+
+  <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='const'>Net</span><span class='op'>::</span><span class='const'>HTTP</span><span class='period'>.</span><span class='id identifier rubyid_start'>start</span><span class='lparen'>(</span><span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_hostname'>hostname</span><span class='comma'>,</span> <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_port'>port</span><span class='comma'>,</span> <span class='label'>use_ssl:</span> <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_scheme'>scheme</span> <span class='op'>==</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>https</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_http'>http</span><span class='op'>|</span>
+    <span class='id identifier rubyid_http'>http</span><span class='period'>.</span><span class='id identifier rubyid_request'>request</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
   <span class='kw'>end</span>
-  <span class='kw'>return</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_res'>res</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span>
+
+  <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -1016,7 +1051,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 28 19:30:06 2019 by
+  Generated on Thu Mar 28 21:41:39 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.18 (ruby-2.5.1).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -97,7 +97,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 28 19:30:06 2019 by
+  Generated on Thu Mar 28 21:41:39 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.18 (ruby-2.5.1).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -97,6 +97,10 @@ chainpoint = Chainpoint.new
 
 <h3 id="submit-hash">Submit Hash</h3>
 
+<p>Use this function to submit a hashes, and receive back the information needed to later retrieve a proof using <code>get_proof</code></p>
+
+<p>By default hashes are submitted to three Nodes to help ensure a proof will become available at the appropriate time. Only one such proof need be permanently stored, the others provide redundancy.</p>
+
 <p><code>ruby
 # hash is SHA256
 # hash = '2fbe59be2be10a4fdeca9c6d3e9f56fc56fb3ee9a8ef2e9be37fced60c264681'
@@ -193,7 +197,7 @@ c.verify('eJyNVMGOHDUQ5SP4BI7MTpXLLtt9Wolf4JTLyC6XmZaWmdF0JyHHhAtH9hMgizYgLkgoR/
 </div></div>
 
       <div id="footer">
-  Generated on Thu Mar 28 19:30:06 2019 by
+  Generated on Thu Mar 28 21:41:39 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.18 (ruby-2.5.1).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -97,6 +97,10 @@ chainpoint = Chainpoint.new
 
 <h3 id="submit-hash">Submit Hash</h3>
 
+<p>Use this function to submit a hashes, and receive back the information needed to later retrieve a proof using <code>get_proof</code></p>
+
+<p>By default hashes are submitted to three Nodes to help ensure a proof will become available at the appropriate time. Only one such proof need be permanently stored, the others provide redundancy.</p>
+
 <p><code>ruby
 # hash is SHA256
 # hash = '2fbe59be2be10a4fdeca9c6d3e9f56fc56fb3ee9a8ef2e9be37fced60c264681'
@@ -193,7 +197,7 @@ c.verify('eJyNVMGOHDUQ5SP4BI7MTpXLLtt9Wolf4JTLyC6XmZaWmdF0JyHHhAtH9hMgizYgLkgoR/
 </div></div>
 
       <div id="footer">
-  Generated on Thu Mar 28 19:30:06 2019 by
+  Generated on Thu Mar 28 21:41:39 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.18 (ruby-2.5.1).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 28 19:30:06 2019 by
+  Generated on Thu Mar 28 21:41:39 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.18 (ruby-2.5.1).
 </div>


### PR DESCRIPTION
Here's the changes I wrote to submit to three nodes, selected at random from a randomly chosen endpoint.

I kept the overall structure the same - but I think it's getting to the point where it would make sense to introduce some additional objects.

For example, a `Chainpoint::Hash` object seems like it would be useful here to store the urls and node ids that a hash was submitted to - currently the array returned by `submit` has a duplicate `hash` key for each item in the array returned:

```
Chainpoint.new.submit_data "abc"

[
  {
    "hash_id_node"=>"bc475570-51db-11e9-bd37-015cc7c60d66",
    "hash"=>"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
    "uri"=>"http://159.89.128.8"
  },
 {
    "hash_id_node"=>"bc62a5a0-51db-11e9-adb3-01de367ea0f6",
    "hash"=>"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
    "uri"=>"http://142.93.73.55"
  },
  {
    "hash_id_node"=>"bca4b7b0-51db-11e9-8239-01e3f97b569d",
    "hash"=>"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
    "uri"=>"http://212.237.60.8"
  }
]
```

I realize this PR changes a lot of the current code - if you would prefer that I fork and create a separate gem, please let me know.